### PR TITLE
dependencies upgrade

### DIFF
--- a/lib/widgets/countries_list.dart
+++ b/lib/widgets/countries_list.dart
@@ -34,9 +34,11 @@ class CountryItem extends StatelessWidget {
           children: [
             CountryFlag.fromCountryCode(
               country.countryCode,
-              height: 18.0,
-              width: 24.0,
-              shape: const RoundedRectangle(3.0),
+              theme: const ImageTheme(
+                width: 24,
+                height: 18,
+                shape: RoundedRectangle(3.0),
+              ),
             ),
             const SizedBox(width: 20.0),
             Expanded(

--- a/lib/widgets/mobile_input.dart
+++ b/lib/widgets/mobile_input.dart
@@ -199,7 +199,9 @@ class _MobileInputState extends State<MobileInput> {
             ? const SizedBox.shrink()
             : CountryFlag.fromCountryCode(
                 _selectedCountry!.countryCode,
-                shape: const RoundedRectangle(3.0),
+                theme: const ImageTheme(
+                  shape: RoundedRectangle(3.0),
+                ),
                 key: ValueKey(_selectedCountry!.countryCode),
               ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ topics:
   - social-login
 
 dependencies:
-  country_flags: ^3.3.0
+  country_flags: ^4.1.0
   device_region: ^1.4.0
   diacritic: ^0.1.6
   flutter:
@@ -30,26 +30,26 @@ dependencies:
   flutter_libphonenumber: ^2.5.1
   flutter_localizations:
     sdk: flutter
-  flutter_secure_storage: ^9.2.2
-  freezed_annotation: ^2.4.4
+  flutter_secure_storage: ^9.2.4
+  freezed_annotation: ^3.1.0
   google_sign_in: ^6.3.0
   google_sign_in_web: ^0.12.4+4
   http: ^1.2.2
-  intl: ^0.20.2
+  intl: any
   json_annotation: ^4.9.0
-  pinput: ^5.0.0
-  provider: ^6.1.2
+  pinput: ^5.0.2
+  provider: ^6.1.5+1
   sign_in_with_apple: ^7.0.1
   styled_text: ^8.1.0
-  url_launcher: ^6.3.1
+  url_launcher: ^6.3.2
 
 dev_dependencies:
-  build_runner: ^2.4.12
-  flutter_lints: ^4.0.0
+  build_runner: ^2.10.1
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
-  freezed: ^2.5.7
-  json_serializable: ^6.8.0
+  freezed: ^3.2.3
+  json_serializable: ^6.11.1
 
 flutter:
   generate: true


### PR DESCRIPTION
Hello,
I simply upgraded some libraries. 
I'm not touching the google_sign libraries because the difference is significant. I'd prefer you to take a look at this library yourself. 
That should already allow those who have switched to Riverpod 3 to use your library.
Thx ;)